### PR TITLE
Add left to right bar growth mode

### DIFF
--- a/defaults.lua
+++ b/defaults.lua
@@ -44,6 +44,7 @@ YaHT.defaults = {
 		timertexture = "Bar",
 		height = 5,
 		width = 300,
+		direction = false,
 		border = 3,
 		alpha = 1,
 		malpha = 0.2,

--- a/locales/deDE.lua
+++ b/locales/deDE.lua
@@ -42,6 +42,9 @@ AceLocale:RegisterTranslations("deDE", function()
 		["Alpha during player movent"] = "Alpha w‰hrend der Spielebewegung",
 		["Bar Texture"] = "Bar Textur",
 		["<texturename>"] = "<texturname>",
+		["L2R Growth"] = "L2R Growth"
+		["Toggle between centered growth and left to right growth"] = "Umschalten zwischen Wachsen von der Mitte nach auﬂen zu Links nach Rechts",
+
 		
 		["Aimed Shot"] = "Gezielter Schuss",
 		["Multi-Shot"] = "Mehrfachschuss",

--- a/locales/enUS.lua
+++ b/locales/enUS.lua
@@ -42,6 +42,8 @@ AceLocale:RegisterTranslations("enUS", function()
 		["Alpha during player movent"] = "Alpha during player movent",
 		["Bar Texture"] = "Bar Texture",
 		["<texturename>"] = "<texturename>",
+		["L2R Growth"] = "L2R Growth",
+		["Toggle between centered growth and left to right growth"] = "Toggle between centered growth and left to right growth",
 		
 		["Aimed Shot"] = "Aimed Shot",
 		["Multi-Shot"] = "Multi-Shot",

--- a/locales/frFR.lua
+++ b/locales/frFR.lua
@@ -42,6 +42,9 @@ AceLocale:RegisterTranslations("frFR", function()
 		["Alpha during player movent"] = "Alpha during player movent",
 		["Bar Texture"] = "Bar Texture",
 		["<texturename>"] = "<texturename>",
+		["L2R Growth"] = "L2R Growth",
+		["Toggle between centered growth and left to right growth"] = "Basculer entre croissance centrée et croissance gauche à droite",
+
 		
 		["Aimed Shot"] = "Vis\195\169e",
 		["Multi-Shot"] = "Fl\195\168ches multiples",

--- a/locales/zhCN.lua
+++ b/locales/zhCN.lua
@@ -42,6 +42,9 @@ AceLocale:RegisterTranslations("zhCN", function()
 		["Alpha during player movent"] = "Alpha during player movent",
 		["Bar Texture"] = "Bar Texture",
 		["<texturename>"] = "<texturename>",
+		["L2R Growth"] = "L2R Growth",
+		["Toggle between centered growth and left to right growth"] = "Toggle between centered growth and left to right growth",
+
 		
 		["Aimed Shot"] = "瞄准射击",
 		["Multi-Shot"] = "多重射击",


### PR DESCRIPTION
Someone asked for this functionality on global. Instead of growing from the middle to both edges, this mode grows from left to right.

Toggleable through: Minimap Icon -> Timer options -> L2R Growth

<sup>My editor automatically removed some unnecessary tabs/whitespaces btw.</sup>