### PR TITLE
compensate for autoshot movement delay

### DIFF
--- a/YaHT.lua
+++ b/YaHT.lua
@@ -327,7 +327,7 @@ function YaHT:START_AUTOREPEAT_SPELL()
 		self.mainFrame.texture:SetVertexColor(config.drawcolor.r,config.drawcolor.g,config.drawcolor.b)
 		self.mainFrame.SwingStart = curTime
 		if IsPlayerMoving() then
-			self.mainFrame.lastshot = curTime
+			self.mainFrame.lastshot = curTime - self.mainFrame.swingtime
 		end
 	end
 	self.mainFrame:SetAlpha(YaHT.db.profile.alpha)

--- a/YaHT.lua
+++ b/YaHT.lua
@@ -10,6 +10,7 @@ YaHT.version = 2110
 
 local SWING_TIME = 0.65
 local AimedDelay = 1
+local movementDelay = 0
 
 local AimedShot = GetSpellInfo(19434)
 local MultiShot = GetSpellInfo(2643)
@@ -56,8 +57,15 @@ local function OnUpdate(self, elapsed)
 			self.SwingStart = curTime
 			self.texture:SetWidth(0.01)
 			self:SetAlpha(config.malpha)
+			local timeSinceReadyToFire = curTime - self.lastshot + self.swingtime
+			if timeSinceReadyToFire > 0 then
+				while timeSinceReadyToFire > 0.5 do
+					timeSinceReadyToFire = timeSinceReadyToFire - 0.5
+				end
+				movementDelay = 0.5 - timeSinceReadyToFire
+			end
 		else
-			self.texture:SetWidth(config.width * math.min(((curTime - self.SwingStart) / SWING_TIME),1))
+			self.texture:SetWidth(config.width * math.min(((curTime - self.SwingStart) / (SWING_TIME + movementDelay)),1))
 			self:SetAlpha(config.alpha)
 		end
 	else
@@ -318,6 +326,9 @@ function YaHT:START_AUTOREPEAT_SPELL()
 	else
 		self.mainFrame.texture:SetVertexColor(config.drawcolor.r,config.drawcolor.g,config.drawcolor.b)
 		self.mainFrame.SwingStart = curTime
+		if IsPlayerMoving() then
+			self.mainFrame.lastshot = curTime
+		end
 	end
 	self.mainFrame:SetAlpha(YaHT.db.profile.alpha)
 	self.mainFrame:Show()
@@ -348,6 +359,7 @@ function YaHT:UNIT_SPELLCAST_SUCCEEDED(unit, castGUID, spellID)
 				self.mainFrame.newswingtime = nil
 			end
 			self.mainFrame.texture:SetVertexColor(config.timercolor.r,config.timercolor.g,config.timercolor.b)
+			movementDelay = 0
 		end
 	end
 end


### PR DESCRIPTION
Per Blizzard's ['Not a Bug' List:](https://us.forums.blizzard.com/en/wow/t/wow-classic-not-a-bug-list/175887)

> Hunters can sometimes experience a slight delay before recasting Auto Shot after moving. There is a hidden “retry” timer that occurs if the hunter is moving when the normal swing timer finishes. This timer checks for hunter movement before trying to resume auto shot, and this timer refreshes every 500ms when the hunter is moving. This means that if a Hunter is moving and stops moving just after this timer refreshes, you need to wait until the retry timer checks again to validate that you are no longer moving and can resume casting auto shot. This is not a result of spell batching or server heartbeats, and is specific to the functionality of a Hunter’s Auto Shot. This is consistent with Auto Shot functionality on the Reference client.

To improve the accuracy of the red _draw-timer_, we can increase the timer's duration by up to 500 ms to compensate for the movement delay.

Example: If player is moving when the swing timer finishes & stops moving 200 ms later, we add 300 ms to the draw-timer.