### PR TITLE
Improve accuracy for shot swing while jumping

### DIFF
--- a/YaHT.lua
+++ b/YaHT.lua
@@ -52,7 +52,7 @@ local function OnUpdate(self, elapsed)
 			end
 		end
 	elseif self.SwingStart then
-		if IsPlayerMoving() then
+		if IsPlayerMoving() or IsFalling() then
 			self.SwingStart = curTime
 			self.texture:SetWidth(0.01)
 			self:SetAlpha(config.malpha)


### PR DESCRIPTION
Currently, the shot swing bar elapses as if the shot is being cast if mid-jump or if jumping during a swing. Like the existing check for movement while swinging, this proposed change considers whether a player is falling (jumping) to reset the swing bar.

API reference: https://wowwiki.fandom.com/wiki/API_IsFalling