### PR TITLE
Show only own Aimed Shot / Multi-Shot as cast bar

### DIFF
--- a/YaHT.lua
+++ b/YaHT.lua
@@ -259,7 +259,7 @@ function YaHT:COMBAT_LOG_EVENT_UNFILTERED()
 			SendChatMessage(string.format(YaHT.db.profile.announcefailmsg,targetName), YaHT.db.profile.announcetype, nil, num or YaHT.db.profile.targetchannel)
 		end
 	end
-	if (name ~= AimedShot and name ~= MultiShot) or (not YaHT.db.profile.showaimed and name == AimedShot) or (not YaHT.db.profile.showmulti and name == MultiShot) then return end
+	if casterID ~= UnitGUID("player") or (name ~= AimedShot and name ~= MultiShot) or (not YaHT.db.profile.showaimed and name == AimedShot) or (not YaHT.db.profile.showmulti and name == MultiShot) then return end
 	if event == "SPELL_CAST_START" then
 		self.mainFrame.casting = true
 		


### PR DESCRIPTION
Currently, a cast bar is shown when other hunters in the area cast Aimed Shot or Multi-Shot. The proposed changes seek to resolve this by testing that the source caster ID for a cast originates from the player.