### PR TITLE
Fix cast bar push back

### DIFF
--- a/YaHT.lua
+++ b/YaHT.lua
@@ -232,7 +232,7 @@ function YaHT:COMBAT_LOG_EVENT_UNFILTERED()
 		if targetID == UnitGUID("player") then
 			local maxValue
 			maxValue = 0
-			if not CastingBarFrame.maxValue == nil then
+			if CastingBarFrame.maxValue ~= nil then
 				maxValue = CastingBarFrame.maxValue
 			end
 			CastingBarFrame.maxValue = maxValue + math.min(CastingBarFrame:GetValue(),AimedDelay)


### PR DESCRIPTION
Fixes #42

This pull request seeks to resolve an issue where the cast bar is cancelled when the player takes damage, instead of adding delay based on pushback of the cast. The issue is caused by an order of operations in the condition `not CastingBarFrame.maxValue == nil`, where `not CastingBarFrame.maxValue` is evaluated before comparing `== nil`, such that the condition will never be satisfied. The fix is to change from `not x == nil` to `x ~= nil`.